### PR TITLE
parallel processing of tasks by forest for data service driver

### DIFF
--- a/state-conductor-dataservices/build.gradle
+++ b/state-conductor-dataservices/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 }
 
 mainClassName = 'com.marklogic.StateConductorDriver'
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 jar {
   manifest {
@@ -49,7 +51,7 @@ jar {
     )
   }
   from {
-    configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+    configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
   }
 }
 

--- a/state-conductor-dataservices/src/main/java/com/marklogic/StateConductorService.java
+++ b/state-conductor-dataservices/src/main/java/com/marklogic/StateConductorService.java
@@ -31,7 +31,7 @@ public interface StateConductorService {
             }
 
             @Override
-            public Stream<String> getJobs(Integer count, String flowNames, Stream<String> flowStatus) {
+            public Stream<String> getJobs(Integer count, String flowNames, Stream<String> flowStatus, Stream<String> forestIds) {
               return BaseProxy.StringType.toString(
                 baseProxy
                 .request("getJobs.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS)
@@ -39,7 +39,8 @@ public interface StateConductorService {
                 .withParams(
                     BaseProxy.atomicParam("count", true, BaseProxy.UnsignedIntegerType.fromInteger(count)),
                     BaseProxy.atomicParam("flowNames", true, BaseProxy.StringType.fromString(flowNames)),
-                    BaseProxy.atomicParam("flowStatus", true, BaseProxy.StringType.fromString(flowStatus)))
+                    BaseProxy.atomicParam("flowStatus", true, BaseProxy.StringType.fromString(flowStatus)),
+                    BaseProxy.atomicParam("forestIds", true, BaseProxy.StringType.fromString(forestIds)))
                 .withMethod("POST")
                 .responseMultiple(true, null)
                 );
@@ -85,9 +86,10 @@ public interface StateConductorService {
    * @param count	The number of uris to return
    * @param flowNames	A list of flow names to filter the returned job documents
    * @param flowStatus	A list of flow status's to filter the returned job documents.  Defaults to 'new' and 'working'.
+   * @param forestIds	The returned list of job documents will be limited to jobs found in this list of forests.
    * @return	as output
    */
-    Stream<String> getJobs(Integer count, String flowNames, Stream<String> flowStatus);
+    Stream<String> getJobs(Integer count, String flowNames, Stream<String> flowStatus, Stream<String> forestIds);
 
   /**
    * Creates a MarkLogic State Conductor Job document for the given uri and flow.

--- a/state-conductor-dataservices/src/test/java/com/marklogic/StateConductorServiceMock.java
+++ b/state-conductor-dataservices/src/test/java/com/marklogic/StateConductorServiceMock.java
@@ -8,7 +8,7 @@ import java.util.stream.Stream;
 public class StateConductorServiceMock implements StateConductorService {
 
   @Override
-  public Stream<String> getJobs(Integer count, String flowNames, Stream<String> flowStatus) {
+  public Stream<String> getJobs(Integer count, String flowNames, Stream<String> flowStatus, Stream<String> forestIds) {
     List<String> uris = new ArrayList<>();
     for (int i = 1; i <= count; i++) {
       uris.add(String.format("/test/test%s.json", i));

--- a/state-conductor-dataservices/src/test/java/com/marklogic/StateConductorServiceTest.java
+++ b/state-conductor-dataservices/src/test/java/com/marklogic/StateConductorServiceTest.java
@@ -69,7 +69,7 @@ public class StateConductorServiceTest extends AbstractStateConductorTest {
   @Test
   public void testGetJobsMock() {
     int count = 10;
-    Object[] uris = mockService.getJobs(count, null, null).toArray();
+    Object[] uris = mockService.getJobs(count, null, null, null).toArray();
     assertEquals(count, uris.length);
     assertEquals("/test/test1.json", uris[0].toString());
     assertEquals("/test/test2.json", uris[1].toString());
@@ -83,7 +83,7 @@ public class StateConductorServiceTest extends AbstractStateConductorTest {
     String[] uris;
     StateConductorJob jobDoc;
 
-    uris = service.getJobs(1000, null, null).toArray(String[]::new);
+    uris = service.getJobs(1000, null, null, null).toArray(String[]::new);
     assertTrue(3 <= uris.length);
     for (int i = 0; i < uris.length; i++) {
       String flowStatus = getJobDocument(uris[i]).getFlowStatus();
@@ -91,14 +91,14 @@ public class StateConductorServiceTest extends AbstractStateConductorTest {
     }
 
     status = new String[]{ "new" };
-    uris = service.getJobs(count, null, Arrays.stream(status)).toArray(String[]::new);
+    uris = service.getJobs(count, null, Arrays.stream(status), null).toArray(String[]::new);
     assertTrue(2 <= uris.length);
     for (int i = 0; i < uris.length; i++) {
       assertEquals("new", getJobDocument(uris[i]).getFlowStatus());
     }
 
     status = new String[]{ "new" };
-    uris = service.getJobs(count, "test-flow", Arrays.stream(status)).toArray(String[]::new);
+    uris = service.getJobs(count, "test-flow", Arrays.stream(status), null).toArray(String[]::new);
     assertTrue(2 <= uris.length);
     for (int i = 0; i < uris.length; i++) {
       assertEquals("new", getJobDocument(uris[i]).getFlowStatus());
@@ -106,28 +106,28 @@ public class StateConductorServiceTest extends AbstractStateConductorTest {
     }
 
     status = new String[]{ "working" };
-    uris = service.getJobs(count, "test-flow", Arrays.stream(status)).toArray(String[]::new);
+    uris = service.getJobs(count, "test-flow", Arrays.stream(status), null).toArray(String[]::new);
     assertEquals(1, uris.length);
     assertEquals("working", getJobDocument(uris[0]).getFlowStatus());
     assertEquals("test-flow", getJobDocument(uris[0]).getFlowName());
     assertEquals("job3", getJobDocument(uris[0]).getId());
 
     status = new String[]{ "complete" };
-    uris = service.getJobs(count, "test-flow", Arrays.stream(status)).toArray(String[]::new);
+    uris = service.getJobs(count, "test-flow", Arrays.stream(status), null).toArray(String[]::new);
     assertEquals(1, uris.length);
     assertEquals("complete", getJobDocument(uris[0]).getFlowStatus());
     assertEquals("test-flow", getJobDocument(uris[0]).getFlowName());
     assertEquals("job4", getJobDocument(uris[0]).getId());
 
     status = new String[]{ "failed" };
-    uris = service.getJobs(count, "test-flow", Arrays.stream(status)).toArray(String[]::new);
+    uris = service.getJobs(count, "test-flow", Arrays.stream(status), null).toArray(String[]::new);
     assertEquals(1, uris.length);
     assertEquals("failed", getJobDocument(uris[0]).getFlowStatus());
     assertEquals("test-flow", getJobDocument(uris[0]).getFlowName());
     assertEquals("job5", getJobDocument(uris[0]).getId());
 
     status = new String[]{ "complete", "failed" };
-    uris = service.getJobs(count, "test-flow", Arrays.stream(status)).toArray(String[]::new);
+    uris = service.getJobs(count, "test-flow", Arrays.stream(status), null).toArray(String[]::new);
     assertTrue(2 <= uris.length);
     for (int i = 0; i < uris.length; i++) {
       String flowStatus = getJobDocument(uris[i]).getFlowStatus();
@@ -135,7 +135,7 @@ public class StateConductorServiceTest extends AbstractStateConductorTest {
       assertEquals("test-flow", getJobDocument(uris[i]).getFlowName());
     }
 
-    uris = service.getJobs(count, "fake-flow", null).toArray(String[]::new);
+    uris = service.getJobs(count, "fake-flow", null, null).toArray(String[]::new);
     assertEquals(0, uris.length);
   }
 

--- a/state-conductor-modules/src/main/ml-modules/root/state-conductor/dataservices/getJobs.api
+++ b/state-conductor-modules/src/main/ml-modules/root/state-conductor/dataservices/getJobs.api
@@ -20,6 +20,13 @@
       "desc": "A list of flow status's to filter the returned job documents.  Defaults to 'new' and 'working'.",
       "nullable": true,
       "multiple": true
+    },
+    {
+      "name": "forestIds",
+      "datatype": "string",
+      "desc": "The returned list of job documents will be limited to jobs found in this list of forests.",
+      "nullable": true,
+      "multiple": true
     }
   ],
   "return": {

--- a/state-conductor-modules/src/main/ml-modules/root/state-conductor/dataservices/getJobs.sjs
+++ b/state-conductor-modules/src/main/ml-modules/root/state-conductor/dataservices/getJobs.sjs
@@ -8,6 +8,7 @@ const sc = require('/state-conductor/state-conductor.sjs');
 var count;
 var flowNames;
 var flowStatus;
+var forestIds;
 
 xdmp.trace(
   sc.TRACE_EVENT,
@@ -36,10 +37,19 @@ if (Array.isArray(flowStatus)) {
   flowStatus = [sc.FLOW_STATUS_NEW, sc.FLOW_STATUS_WORKING];
 }
 
+if (Array.isArray(forestIds)) {
+  // continue
+} else if (forestIds instanceof Sequence) {
+  forestIds = forestIds.toArray();
+} else if (typeof forestIds === 'string') {
+  forestIds = forestIds.split(',');
+}
+
 let options = {
   count: count,
   flowStatus: flowStatus,
   flowNames: flowNames,
+  forestIds: forestIds,
   startDate: null,
   endDate: null,
 };

--- a/state-conductor-modules/src/main/ml-modules/root/state-conductor/state-conductor.sjs
+++ b/state-conductor-modules/src/main/ml-modules/root/state-conductor/state-conductor.sjs
@@ -1300,6 +1300,7 @@ function getJobDocuments(options) {
     : [FLOW_STATUS_NEW, FLOW_STATUS_WORKING];
   const flowNames = Array.isArray(options.flowNames) ? options.flowNames : [];
   const resumeWait = options.resumeWait;
+  const forestIds = options.forestIds;
   let uris = [];
 
   invokeOrApplyFunction(
@@ -1320,30 +1321,26 @@ function getJobDocuments(options) {
       if (options.endDate) {
         queries.push(cts.jsonPropertyRangeQuery('createdDate', '<=', xs.dateTime(options.endDate)));
       }
-      if (fn.exists(resumeWait) && resumeWait === false) {
-        uris = uris.concat(
-          cts.uris('', ['document', `limit=${count}`], cts.andQuery(queries)).toArray()
-        );
-      } else {
-        uris = uris.concat(
-          cts
-            .uris(
-              '',
-              ['document', `limit=${count}`],
-              cts.orQuery([
-                cts.andQuery(queries),
-                cts.andQuery([
-                  cts.collectionQuery('stateConductorJob'),
-                  cts.jsonPropertyScopeQuery(
-                    'currentlyWaiting',
-                    cts.jsonPropertyRangeQuery('nextTaskTime', '<=', fn.currentDateTime())
-                  ),
-                ]),
-              ])
-            )
-            .toArray()
-        );
+
+      let ctsQuery = cts.andQuery(queries);
+
+      // add any "waiting" jobs that should be resumed - unless explicitly told not to
+      if (!fn.exists(resumeWait) || resumeWait) {
+        ctsQuery = cts.orQuery([
+          ctsQuery,
+          cts.andQuery([
+            cts.collectionQuery('stateConductorJob'),
+            cts.jsonPropertyScopeQuery(
+              'currentlyWaiting',
+              cts.jsonPropertyRangeQuery('nextTaskTime', '<=', fn.currentDateTime())
+            ),
+          ]),
+        ]);
       }
+
+      uris = uris.concat(
+        cts.uris('', ['document', `limit=${count}`], ctsQuery, null, forestIds).toArray()
+      );
     },
     {
       database: xdmp.database(STATE_CONDUCTOR_JOBS_DB),


### PR DESCRIPTION
Performance optimization of data service driver
- getJobs now accepts a forest id filter
- the Data service driver now detects how many jobs database forests are present
- the Data service driver will create a separate driver thread per forest