### PR TITLE
Capture errors during batch processing to isolate failures.

### DIFF
--- a/state-conductor-dataservices/src/main/java/com/marklogic/tasks/ProcessJobTask.java
+++ b/state-conductor-dataservices/src/main/java/com/marklogic/tasks/ProcessJobTask.java
@@ -12,17 +12,19 @@ public class ProcessJobTask implements Callable<JsonNode> {
 
   Logger logger = LoggerFactory.getLogger(ProcessJobTask.class);
 
+  private Integer id;
   private StateConductorService service;
   private List<String> jobUris;
 
-  public ProcessJobTask(StateConductorService service, List<String> jobUris) {
+  public ProcessJobTask(Integer id, StateConductorService service, List<String> jobUris) {
+    this.id = id;
     this.service = service;
     this.jobUris = jobUris;
   }
 
   @Override
   public JsonNode call() throws Exception {
-    logger.info("processing batch job: {}", jobUris);
+    logger.info("processing batch job: {} [size: {}]", id, jobUris.size());
     return service.processJob(jobUris.stream());
   }
 }

--- a/state-conductor-dataservices/src/test/resources/jobs/badJob1.json
+++ b/state-conductor-dataservices/src/test/resources/jobs/badJob1.json
@@ -1,0 +1,13 @@
+{
+  "id": "badJob1",
+  "flowName": "missing-flow",
+  "flowStatus": "new",
+  "flowState": null,
+  "uri": "/test/doc1.json",
+  "database": "%DATABASE%",
+  "modules": "%MODULES%",
+  "createdDate": "2020-03-30T17:20:00.362Z",
+  "context": {},
+  "provenance": [],
+  "errors": {}
+}

--- a/state-conductor-modules/src/main/ml-modules/root/state-conductor/dataservices/processJob.sjs
+++ b/state-conductor-modules/src/main/ml-modules/root/state-conductor/dataservices/processJob.sjs
@@ -18,18 +18,27 @@ if (Array.isArray(uri)) {
 }
 
 let resp = uri.map((value) => {
-  let result = sc.invokeOrApplyFunction(
-    () => {
-      declareUpdate();
-      return sc.processJob(value);
-    },
-    {
-      database: xdmp.database(sc.STATE_CONDUCTOR_JOBS_DB),
-    }
-  );
+  let result = false;
+  let error;
+  // handle errors individually so the batch can continue
+  try {
+    result = sc.invokeOrApplyFunction(
+      () => {
+        declareUpdate();
+        return sc.processJob(value);
+      },
+      {
+        database: xdmp.database(sc.STATE_CONDUCTOR_JOBS_DB),
+      }
+    );
+  } catch (err) {
+    error = err;
+  }
+
   return {
     job: value,
     result: result,
+    error: error,
   };
 });
 


### PR DESCRIPTION
Fixes #59 

Capture failures fetching job documents to stop processes from terminating if ML restarts or goes down.